### PR TITLE
Sometimes passed in id is an empty string instead of nil

### DIFF
--- a/lib/reactive_resource/base.rb
+++ b/lib/reactive_resource/base.rb
@@ -80,7 +80,7 @@ module ReactiveResource
       element_path = "#{prefix(prefix_options)}#{association_prefix(prefix_options)}#{collection_name}"
 
       # singleton resources don't have an ID
-      if id || !singleton?
+      if id.present? || !singleton?
         element_path += "/#{id}"
       end
       element_path += "#{extension}#{query_string(query_options)}"

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -18,6 +18,10 @@ class ReactiveResource::BaseTest < Test::Unit::TestCase
     should "follow relationships where :class_name is specified" do
       assert_equal ReactiveResource::Lawyer, @object.class.associations.detect {|assoc| assoc.attribute == :lawyer }.associated_class
     end
+
+    should "return valid path when id is blank" do
+      assert_equal "/api/1/headshot.json", ReactiveResource::Headshot.element_path('')
+    end
   end
 
   context "A resource that inherits from ReactiveResource::Base" do


### PR DESCRIPTION
In this case it should be handled correctly and doesn't return path/.extension when getting the path string.
This is only broken for singleton classes because other classes "should" have ids.
