### PR TITLE
Gracefully handle attributes = nil on construction

### DIFF
--- a/lib/reactive_resource/base.rb
+++ b/lib/reactive_resource/base.rb
@@ -92,7 +92,7 @@ module ReactiveResource
     # be in the URL anyway), so we'll try to inject them based on the
     # attributes of the object we just used.
     def load(attributes, remove_root=false)
-      attributes = attributes.stringify_keys
+      attributes = attributes ? attributes.stringify_keys : {}
       self.class.belongs_to_with_parents.each do |belongs_to_param|
         attributes["#{belongs_to_param}_id"] ||= prefix_options["#{belongs_to_param}_id".intern]
 


### PR DESCRIPTION
This is actually also a bug in ActiveResource, but exists here too: If you do something like

```
@user = User.new(params[:user])
```

but params[:user] is not set (is nil, e.g because the user reloaded the page you POSTed to), you'll get an ugly error coming from reactive_resource:

```
NoMethodError (undefined method `stringify_keys' for nil:NilClass):
app/controllers/users_controller.rb:13:in `new'
app/controllers/users_controller.rb:13:in `create'
```

Given that e.g. ActiveRecord handles this case nicely, I have made a simple change that lets reactive_resource do likewise.
